### PR TITLE
Better GLSL support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,14 @@ path = "src/triangle/main.rs"
 [dependencies]
 gfx_gl = "*"
 glfw = "*"
-cgmath = "*"
 rand = "*"
 time = "*"
 genmesh = "*"
 noise = "*"
+
+[dependencies.cgmath]
+git = "https://github.com/bjz/cgmath-rs"
+#version = "*"
 
 [dependencies.gfx]
 git = "https://github.com/gfx-rs/gfx-rs"

--- a/src/cube/README.md
+++ b/src/cube/README.md
@@ -20,6 +20,10 @@ A simple example showing how to render a textured cube using vertex and index
 buffers, GLSL shaders, and uniform parameters. It is also using cgmath-rs to
 compute the view-projection matrix.
 
+The example provides two versions of each shader: for GLSL 1.20 and 1.50-core.
+This is needed for proper OSX compatibility and ensures it can run on any
+system.
+
 ## Screenshot
 
 ![Cube Example](screenshot.png)

--- a/src/cube/cube_120.glslf
+++ b/src/cube/cube_120.glslf
@@ -1,0 +1,10 @@
+#version 120
+
+varying vec2 v_TexCoord;
+uniform sampler2D t_Color;
+
+void main() {
+    vec4 tex = texture2D(t_Color, v_TexCoord);
+    float blend = dot(v_TexCoord-vec2(0.5,0.5), v_TexCoord-vec2(0.5,0.5));
+    gl_FragColor = mix(tex, vec4(0.0,0.0,0.0,0.0), blend*1.0);
+}

--- a/src/cube/cube_120.glslv
+++ b/src/cube/cube_120.glslv
@@ -1,0 +1,12 @@
+#version 120
+
+attribute vec3 a_Pos;
+attribute vec2 a_TexCoord;
+varying vec2 v_TexCoord;
+
+uniform mat4 u_Transform;
+
+void main() {
+    v_TexCoord = a_TexCoord;
+    gl_Position = u_Transform * vec4(a_Pos, 1.0);
+}

--- a/src/cube/cube_150.glslf
+++ b/src/cube/cube_150.glslf
@@ -1,0 +1,11 @@
+#version 150 core
+
+in vec2 v_TexCoord;
+out vec4 o_Color;
+uniform sampler2D t_Color;
+
+void main() {
+    vec4 tex = texture(t_Color, v_TexCoord);
+    float blend = dot(v_TexCoord-vec2(0.5,0.5), v_TexCoord-vec2(0.5,0.5));
+    o_Color = mix(tex, vec4(0.0,0.0,0.0,0.0), blend*1.0);
+}

--- a/src/cube/cube_150.glslv
+++ b/src/cube/cube_150.glslv
@@ -1,0 +1,12 @@
+#version 150 core
+
+in vec3 a_Pos;
+in vec2 a_TexCoord;
+out vec2 v_TexCoord;
+
+uniform mat4 u_Transform;
+
+void main() {
+    v_TexCoord = a_TexCoord;
+    gl_Position = u_Transform * vec4(a_Pos, 1.0);
+}

--- a/src/cube/main.rs
+++ b/src/cube/main.rs
@@ -54,10 +54,6 @@ struct Params<R: gfx::Resources> {
 
 pub fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
-    glfw.window_hint(glfw::WindowHint::ContextVersion(3, 2));
-    glfw.window_hint(glfw::WindowHint::OpenglForwardCompat(true));
-    glfw.window_hint(glfw::WindowHint::OpenglProfile(glfw::OpenGlProfileHint::Core));
-
     let (mut window, events) = glfw
         .create_window(640, 480, "Cube example", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");

--- a/src/cube/main.rs
+++ b/src/cube/main.rs
@@ -49,33 +49,6 @@ struct Params<R: gfx::Resources> {
     color: gfx::shade::TextureParam<R>,
 }
 
-static VERTEX_SRC: &'static [u8] = b"
-    #version 120
-
-    attribute vec3 a_Pos;
-    attribute vec2 a_TexCoord;
-    varying vec2 v_TexCoord;
-
-    uniform mat4 u_Transform;
-
-    void main() {
-        v_TexCoord = a_TexCoord;
-        gl_Position = u_Transform * vec4(a_Pos, 1.0);
-    }
-";
-
-static FRAGMENT_SRC: &'static [u8] = b"
-    #version 120
-
-    varying vec2 v_TexCoord;
-    uniform sampler2D t_Color;
-
-    void main() {
-        vec4 tex = texture2D(t_Color, v_TexCoord);
-        float blend = dot(v_TexCoord-vec2(0.5,0.5), v_TexCoord-vec2(0.5,0.5));
-        gl_FragColor = mix(tex, vec4(0.0,0.0,0.0,0.0), blend*1.0);
-    }
-";
 
 //----------------------------------------
 
@@ -162,7 +135,20 @@ pub fn main() {
                                    gfx::tex::WrapMode::Clamp)
     );
 
-    let program = factory.link_program(VERTEX_SRC, FRAGMENT_SRC).unwrap();
+    let program = {
+        let vs = gfx::ShaderSource {
+            glsl_120: Some(include_bytes!("cube_120.glslv")),
+            glsl_150: Some(include_bytes!("cube_150.glslv")),
+            .. gfx::ShaderSource::empty()
+        };
+        let fs = gfx::ShaderSource {
+            glsl_120: Some(include_bytes!("cube_120.glslf")),
+            glsl_150: Some(include_bytes!("cube_150.glslf")),
+            .. gfx::ShaderSource::empty()
+        };
+        factory.link_program_source(vs, fs, &device.get_capabilities())
+               .unwrap()
+    };
 
     let view: AffineMatrix3<f32> = Transform::look_at(
         &Point3::new(1.5f32, -5.0, 3.0),

--- a/src/deferred/README.md
+++ b/src/deferred/README.md
@@ -16,7 +16,7 @@
 
 # Deferred Shading Example
 
-This is an example of deferred shading with gfx-rs. It demonstrates the use of render targets and uniform buffers.
+This is an example of deferred shading with gfx-rs. It demonstrates the use of render targets and uniform buffers. It requires GL-3.2 to run.
 
 Two render targets are created: a geometry buffer and a result buffer.
 

--- a/src/deferred/main.rs
+++ b/src/deferred/main.rs
@@ -134,17 +134,17 @@ struct BlitParams<R: gfx::Resources> {
 }
 
 static TERRAIN_VERTEX_SRC: &'static [u8] = b"
-    #version 120
+    #version 150 core
 
     uniform mat4 u_Model;
     uniform mat4 u_View;
     uniform mat4 u_Proj;
-    attribute vec3 a_Pos;
-    attribute vec3 a_Normal;
-    attribute vec3 a_Color;
-    varying vec3 v_FragPos;
-    varying vec3 v_Normal;
-    varying vec3 v_Color;
+    in vec3 a_Pos;
+    in vec3 a_Normal;
+    in vec3 a_Color;
+    out vec3 v_FragPos;
+    out vec3 v_Normal;
+    out vec3 v_Color;
 
     void main() {
         v_FragPos = (u_Model * vec4(a_Pos, 1.0)).xyz;
@@ -155,27 +155,30 @@ static TERRAIN_VERTEX_SRC: &'static [u8] = b"
 ";
 
 static TERRAIN_FRAGMENT_SRC: &'static [u8] = b"
-    #version 130
+    #version 150 core
 
-    varying vec3 v_FragPos;
-    varying vec3 v_Normal;
-    varying vec3 v_Color;
+    in vec3 v_FragPos;
+    in vec3 v_Normal;
+    in vec3 v_Color;
+    out o_Position;
+    out o_Normal;
+    out o_Color;
 
     void main() {
         vec3 n = normalize(v_Normal);
 
-        gl_FragData[0] = vec4(v_FragPos, 0.0);
-        gl_FragData[1] = vec4(n, 0.0);
-        gl_FragData[2] = vec4(v_Color, 1.0);
+        o_Position = vec4(v_FragPos, 0.0);
+        o_Normal = vec4(n, 0.0);
+        o_Color = vec4(v_Color, 1.0);
     }
 ";
 
 static BLIT_VERTEX_SRC: &'static [u8] = b"
-    #version 120
+    #version 150 core
 
-    attribute vec3 a_Pos;
-    attribute vec2 a_TexCoord;
-    varying vec2 v_TexCoord;
+    in vec3 a_Pos;
+    in vec2 a_TexCoord;
+    out vec2 v_TexCoord;
 
     void main() {
         v_TexCoord = a_TexCoord;
@@ -184,26 +187,25 @@ static BLIT_VERTEX_SRC: &'static [u8] = b"
 ";
 
 static BLIT_FRAGMENT_SRC: &'static [u8] = b"
-    #version 120
+    #version 150 core
 
     uniform sampler2D u_Tex;
-    varying vec2 v_TexCoord;
+    in vec2 v_TexCoord;
+    out vec4 o_Color;
 
     void main() {
-        vec4 tex = texture2D(u_Tex, v_TexCoord);
-        gl_FragColor = tex;
+        vec4 tex = texture(u_Tex, v_TexCoord);
+        o_Color = tex;
     }
 ";
 
 static LIGHT_VERTEX_SRC: &'static [u8] = b"
-    #version 140
-    #extension GL_EXT_draw_instanced : enable
-    #extension GL_ARB_uniform_buffer_object : enable
+    #version 150 core
 
     uniform mat4 u_Transform;
     uniform float u_Radius;
-    attribute vec3 a_Pos;
-    varying vec3 v_LightPos;
+    in vec3 a_Pos;
+    out vec3 v_LightPos;
 
     const int NUM_LIGHTS = 250;
     layout(std140)
@@ -218,7 +220,7 @@ static LIGHT_VERTEX_SRC: &'static [u8] = b"
 ";
 
 static LIGHT_FRAGMENT_SRC: &'static [u8] = b"
-    #version 120
+    #version 150 core
 
     uniform float u_Radius;
     uniform vec3 u_CameraPos;
@@ -226,13 +228,14 @@ static LIGHT_FRAGMENT_SRC: &'static [u8] = b"
     uniform sampler2D u_TexPos;
     uniform sampler2D u_TexNormal;
     uniform sampler2D u_TexDiffuse;
-    varying vec3 v_LightPos;
+    in vec3 v_LightPos;
+    out vec4 o_Color;
 
     void main() {
         vec2 texCoord = gl_FragCoord.xy / u_FrameRes;
-        vec3 pos     = texture2D(u_TexPos,     texCoord).xyz;
-        vec3 normal  = texture2D(u_TexNormal,  texCoord).xyz;
-        vec3 diffuse = texture2D(u_TexDiffuse, texCoord).xyz;
+        vec3 pos     = texture(u_TexPos,     texCoord).xyz;
+        vec3 normal  = texture(u_TexNormal,  texCoord).xyz;
+        vec3 diffuse = texture(u_TexDiffuse, texCoord).xyz;
 
         vec3 light    = v_LightPos;
         vec3 to_light = normalize(light - pos);
@@ -247,18 +250,16 @@ static LIGHT_FRAGMENT_SRC: &'static [u8] = b"
 
         vec3 res_color = d*vec3(diffuse) + vec3(s);
 
-        gl_FragColor = vec4(scale*res_color, 1.0);
+        o_Color = vec4(scale*res_color, 1.0);
     }
 ";
 
 static EMITTER_VERTEX_SRC: &'static [u8] = b"
-    #version 140
-    #extension GL_EXT_draw_instanced : enable
-    #extension GL_ARB_uniform_buffer_object : enable
+    #version 150 core
 
     uniform mat4 u_Transform;
     uniform float u_Radius;
-    attribute vec3 a_Pos;
+    in vec3 a_Pos;
 
     const int NUM_LIGHTS = 250;
     layout(std140)
@@ -272,10 +273,12 @@ static EMITTER_VERTEX_SRC: &'static [u8] = b"
 ";
 
 static EMITTER_FRAGMENT_SRC: &'static [u8] = b"
-    #version 120
+    #version 150 core
+
+    out vec4 o_Color;
 
     void main() {
-        gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+        o_Color = vec4(1.0, 1.0, 1.0, 1.0);
     }
 ";
 

--- a/src/terrain/main.rs
+++ b/src/terrain/main.rs
@@ -110,10 +110,6 @@ fn calculate_color(height: f32) -> [f32; 3] {
 
 pub fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
-    glfw.window_hint(glfw::WindowHint::ContextVersion(3, 2));
-    glfw.window_hint(glfw::WindowHint::OpenglForwardCompat(true));
-    glfw.window_hint(glfw::WindowHint::OpenglProfile(glfw::OpenGlProfileHint::Core));
-
     let (mut window, events) = glfw
         .create_window(800, 600, "Terrain example", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");


### PR DESCRIPTION
Closes #13 

I figured that moving each and every shader into external files does not give us that much:
  1. We demonstrate `ShaderSource` usage in the cube example
  2. Deferred example used to require GLSL-1.40 plus extensions. I just switched it to GLSL-1.50-core, since the gap to it is very narrow, and now it's gonna run on OSX
  3. Removed the GL context constraints for the terrain example, which will not work on OSX out of the box.